### PR TITLE
Example of NPM Publish for bats-support as scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,20 @@
 {
-  "name": "bats-support",
+  "name": "@pauldruce/bats-support",
   "version": "0.3.0",
   "description": "Supporting library for Bats test helpers",
-  "homepage": "https://github.com/jasonkarns/bats-support",
+  "homepage": "https://github.com/bats-core/bats-support#readme",
   "license": "CC0-1.0",
-  "author": "Zoltán Tömböl (https://github.com/ztombol)",
-  "contributors": [
-    "Jason Karns <jason.karns@gmail.com> (http://jason.karns.name)"
-  ],
-  "repository": "github:jasonkarns/bats-support",
-  "bugs": "https://github.com/jasonkarns/bats-support/issues",
-  "directories": {
-    "lib": "src",
-    "test": "test"
-  },
+  "author": "Bats-core Organization",
+  "repository": "github:bats-core/bats-support",
+  "bugs": "https://github.com/bats-core/bats-support/issues",
   "files": [
     "load.bash",
     "src"
   ],
+  "directories": {
+    "lib": "src",
+    "test": "test"
+  },
   "scripts": {
     "test": "bats ${CI+-t} test"
   },
@@ -26,5 +23,12 @@
   },
   "peerDependencies": {
     "bats": "0.4 || ^1"
-  }
+  },
+  "keywords": [
+    "bats",
+    "bash",
+    "shell",
+    "test",
+    "unit"
+  ]
 }


### PR DESCRIPTION
I've updated the package.lock a little - just to make sure the published package is scoped to my username. 

I've published bats-support under the scope of my username (so others don't accidentally install it). 
You can see the package here: https://www.npmjs.com/package/@pauldruce/bats-support/access



Everything is governed by the package.json file.

Some info about how to test/check what is being published and what would be installed using npm:
- You can install a package from the source files in the following way: `npm install <path-to-source-code>`. So i.e. `npm install /home/pauldruce/bats-support` would work. 
- You can check what is packaged up to publish with: `npm pack --dry-run`, this should produce something like
  ```
  ❯ npm pack --dry-run
  npm notice
  npm notice 📦  @pauldruce/bats-support@0.3.0
  npm notice Tarball Contents
  npm notice 6.6kB LICENSE
  npm notice 5.0kB README.md
  npm notice 476B load.bash
  npm notice 700B package.json
  npm notice 1.0kB src/error.bash
  npm notice 2.0kB src/lang.bash
  npm notice 6.7kB src/output.bash
  npm notice Tarball Details
  npm notice name: @pauldruce/bats-support
  npm notice version: 0.3.0
  npm notice filename: pauldruce-bats-support-0.3.0.tgz
  npm notice package size: 7.8 kB
  npm notice unpacked size: 22.5 kB
  npm notice shasum: 3556b08da4a711449868f6593d028a138260ca36
  npm notice integrity: sha512-qHqxdbxvD0OMe[...]/MG8glEfUgy1w==
  npm notice total files: 7
  npm notice
  pauldruce-bats-support-0.3.0.tgz
  ```

To publish this, we need to login in to the npmjs registry `npm login --registry=https://registry.npmjs.org`. 
Then you can publish using `npm publish --registry=https://registry.npmjs.org --access public` - by default this tried to publish as a private package which requires paying for. 

